### PR TITLE
Change scale for width divisible by 2 error

### DIFF
--- a/videos/encode.py
+++ b/videos/encode.py
@@ -29,6 +29,6 @@ for filepath in newFiles:
 	o = os.path.join(destinationDirectory, newFile)
 	if os.path.isfile(o):
 		continue
-	encodeCommand = 'ffmpeg -i "%s" -vf scale=-1:480 -c:v libx264 -profile:v baseline -level 3.0 -preset fast -crf 23 -pix_fmt yuv420p "%s"' % (i, o)
+	encodeCommand = 'ffmpeg -i "%s" -vf scale=-2:480 -c:v libx264 -profile:v baseline -level 3.0 -preset fast -crf 23 -pix_fmt yuv420p "%s"' % (i, o)
 	print('Encoding %s' % newFile)
 	encode = os.popen(encodeCommand).read()


### PR DESCRIPTION
The current ffmpeg can generate a width not divisible by 2 error. This resolves that error.